### PR TITLE
Fixed typo causing no output

### DIFF
--- a/R/construct_null.R
+++ b/R/construct_null.R
@@ -288,7 +288,7 @@ constructNull <- function(mat,
 
     } else {
       message("No correlation structure. All features are independent.")
-      newMat_list <- lapply(seq_lennRep, function(x) {
+      newMat_list <- lapply(seq_len(nRep), function(x) {
         newMat <- matrix(0, nrow = n_gene, ncol = n_cell)
         rownames(newMat) <- gene_names
         colnames(newMat) <- paste0("Cell", seq_len(n_cell))


### PR DESCRIPTION
Hi,

While running ClusterDE's constructNull, I was running into the following error:

`error in constructNull(mat = ex, family = "gaussian", formula = NULL,  :
  object 'newMat_list' not found`

Looking into he code, it seems there's a typo where `seq_len(nRep)` isn't called correctly, but rather is just a string `seq_lennRep`. I believe this should fix the issue.

Thanks,
Daniel (Post doc in Dr. Wei Li's group at UCI)